### PR TITLE
media-assets-collection-solution

### DIFF
--- a/packages/2d/src/lib/scenes/Scene2D.ts
+++ b/packages/2d/src/lib/scenes/Scene2D.ts
@@ -1,5 +1,4 @@
 import type {
-  AssetInfo,
   FullSceneDescription,
   Inspectable,
   InspectedAttributes,
@@ -161,51 +160,6 @@ export class Scene2D extends GeneratorScene<View2D> implements Inspectable {
     for (const node of this.registeredNodes.values()) {
       if (!node.parent() && node !== this.view) yield node;
     }
-  }
-
-  public override getMediaAssets(): Array<AssetInfo> {
-    const playingVideos = Array.from(this.registeredNodes.values())
-      .filter((node): node is Video => node instanceof Video)
-      .filter(video => (video as Video).isPlaying());
-
-    const playingAudios = Array.from(this.registeredNodes.values())
-      .filter((node): node is Audio => node instanceof Audio)
-      .filter(audio => (audio as Audio).isPlaying());
-
-    const returnObjects: AssetInfo[] = [];
-
-    returnObjects.push(
-      ...playingVideos.map(vid => ({
-        key: vid.key,
-        type: 'video' as const,
-        src: vid.src(),
-        decoder: vid.decoder(),
-        playbackRate:
-          typeof vid.playbackRate === 'function'
-            ? vid.playbackRate()
-            : vid.playbackRate,
-        volume: vid.getVolume(),
-        currentTime: vid.getCurrentTime(),
-        duration: vid.getDuration(),
-      })),
-    );
-
-    returnObjects.push(
-      ...playingAudios.map(audio => ({
-        key: audio.key,
-        type: 'audio' as const,
-        src: audio.src(),
-        playbackRate:
-          typeof audio.playbackRate === 'function'
-            ? audio.playbackRate()
-            : audio.playbackRate,
-        volume: audio.getVolume(),
-        currentTime: audio.getCurrentTime(),
-        duration: audio.getDuration(),
-      })),
-    );
-
-    return returnObjects;
   }
 
   public override stopAllMedia() {

--- a/packages/core/src/app/Renderer.ts
+++ b/packages/core/src/app/Renderer.ts
@@ -273,7 +273,7 @@ export class Renderer {
     let lastRefresh = performance.now();
     let result = RendererResult.Success;
 
-    const mediaByFrames = await this.getMediaByFrames(settings);
+    const mediaByFrames: AssetInfo[][] = [];
 
     // Start audio export
     let generateAudioPromise;
@@ -378,43 +378,5 @@ export class Renderer {
       this.playback.currentScene.name,
       signal,
     );
-  }
-
-  private async getMediaByFrames(settings: RendererSettings) {
-    this.stage.configure(settings);
-    this.playback.fps = settings.fps;
-    this.playback.state = PlaybackState.Rendering;
-    const from = this.status.secondsToFrames(settings.range[0]);
-    this.frame.current = from;
-
-    await this.reloadScenes(settings);
-    await this.playback.recalculate();
-    await this.playback.reset();
-
-    const to = Math.min(
-      this.playback.duration,
-      this.status.secondsToFrames(settings.range[1]),
-    );
-    await this.playback.seek(from);
-
-    const mediaAssets: AssetInfo[][] = [];
-    try {
-      const currentMediaAssets = this.playback.currentScene.getMediaAssets();
-      mediaAssets.push(currentMediaAssets);
-
-      let finished = false;
-      while (!finished) {
-        await this.playback.progress();
-        mediaAssets.push(this.playback.currentScene.getMediaAssets());
-
-        if (this.playback.finished || this.playback.frame >= to) {
-          finished = true;
-        }
-      }
-    } catch (e: any) {
-      this.project.logger.error(e);
-    }
-
-    return mediaAssets;
   }
 }

--- a/packages/core/src/scenes/GeneratorScene.ts
+++ b/packages/core/src/scenes/GeneratorScene.ts
@@ -1,4 +1,4 @@
-import type {AssetInfo, Logger, PlaybackStatus} from '../app';
+import type {Logger, PlaybackStatus} from '../app';
 import {decorate, threadable} from '../decorators';
 import {EventDispatcher, ValueDispatcher} from '../events';
 import type {SignalValue} from '../signals';
@@ -98,10 +98,6 @@ export abstract class GeneratorScene<T>
 
   public get previous() {
     return this.previousScene;
-  }
-
-  public getMediaAssets(): Array<AssetInfo> {
-    return [];
   }
 
   public stopAllMedia(): void {}

--- a/packages/core/src/scenes/Scene.ts
+++ b/packages/core/src/scenes/Scene.ts
@@ -1,9 +1,4 @@
-import type {
-  AssetInfo,
-  Logger,
-  PlaybackStatus,
-  SharedWebGLContext,
-} from '../app';
+import type {Logger, PlaybackStatus, SharedWebGLContext} from '../app';
 import type {SubscribableEvent, SubscribableValueEvent} from '../events';
 import type {Plugin} from '../plugin';
 import type {SignalValue} from '../signals';
@@ -324,11 +319,6 @@ export interface Scene<T = unknown> {
    * Should always return `true`.
    */
   isCached(): boolean;
-
-  /**
-   * Get all media assets
-   */
-  getMediaAssets(): Array<AssetInfo>;
 
   stopAllMedia(): void;
 


### PR DESCRIPTION
## Summary
- remove scene media asset retrieval APIs from scene definitions and 2D generator scenes
- update the renderer to no longer collect media metadata and provide exporters with an empty media timeline

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d9f45809c48328b38211df98f4c7cf