### PR TITLE
Add tests for text-font-apply-and-fonts-ready

### DIFF
--- a/packages/proximal-testing-videos/src/text_font_loading_wait.tsx
+++ b/packages/proximal-testing-videos/src/text_font_loading_wait.tsx
@@ -1,0 +1,76 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Txt, makeScene2D} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
+
+/**
+ * This scene introduces a web font and starts rendering immediately without
+ * awaiting its load. With font-waiting logic present, frames block until the
+ * font is ready; without it, early frames render with fallback metrics.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  // Inject a web font into document.fonts and start loading it, but do not await.
+  // Using a deterministic Google-hosted WOFF2.
+  const fontUrl = 'https://fonts.gstatic.com/s/robotoslab/v24/BngMUXZYTXPIvIBgJJSb6ufN5qU.woff2';
+  const ff = new FontFace('TestWebFont', `url(${fontUrl})`);
+  // Add first so document.fonts.ready will include this pending face
+  document.fonts.add(ff);
+  // Start loading asynchronously
+  void ff.load();
+
+  // Immediately apply the font and text styles; with the old behavior, drawing
+  // waits for fonts; with the removed behavior, early frames will use fallback.
+  view.fontFamily('TestWebFont, serif');
+  view.fontSize(64);
+  view.lineHeight('140%');
+  view.textWrap(true);
+  view.textAlign('center');
+
+  const title = createRef<Txt>();
+
+  view.add(
+    <Txt
+      ref={title}
+      width={'80%'}
+      // Intentionally long text to induce wrapping and measurable layout
+      // differences between fallback and the loaded web font.
+    >
+      The quick brown fox jumps over the lazy dog — every glyph matters.
+    </Txt>,
+  );
+
+  // Provide some motion to generate multiple frames while the font is still loading.
+  yield* waitFor(0.25);
+  yield* all(title().scale(1.05, 0.75), title().rotation(5, 0.75));
+  yield* all(title().scale(1.0, 0.75), title().rotation(0, 0.75));
+  yield* waitFor(0.5);
+});
+
+export const project = makeProject({
+  name: 'text_font_loading_wait',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/text_layout_properties.tsx
+++ b/packages/proximal-testing-videos/src/text_layout_properties.tsx
@@ -1,0 +1,87 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Txt, makeScene2D, Layout} from '@revideo/2d';
+import {all, createRef} from '@revideo/core';
+
+/**
+ * This scene stresses layout-affecting text properties: fontFamily, fontSize,
+ * fontWeight, fontStyle, lineHeight, letterSpacing, textWrap, and textAlign.
+ * If style application is disabled, DOM measurement used for placement will
+ * ignore these, causing different line breaks and alignment.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  // Use the same font as the other scene to maximize layout differences.
+  const fontUrl = 'https://fonts.gstatic.com/s/robotoslab/v24/BngMUXZYTXPIvIBgJJSb6ufN5qU.woff2';
+  const ff = new FontFace('TestWebFont', `url(${fontUrl})`);
+  document.fonts.add(ff);
+  void ff.load();
+
+  view.fontFamily('TestWebFont, serif');
+  view.fontSize(42);
+  view.lineHeight('150%');
+  view.textWrap(true);
+
+  const header = createRef<Txt>();
+  const body = createRef<Layout>();
+
+  view.add(
+    <Txt
+      ref={header}
+      fontWeight={700}
+      fontStyle={'italic'}
+      textAlign={'center'}
+      letterSpacing={1.5}
+      width={'90%'}
+    >
+      Measuring styled text: weight, italics, spacing, and alignment
+    </Txt>,
+  );
+
+  view.add(
+    <Txt
+      ref={body}
+      y={80}
+      width={520}
+      textAlign={'right'}
+      letterSpacing={0.75}
+    >
+      Lorem ipsum dolor sit amet, consectetur adipiscing elit. Sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Vestibulum ante ipsum primis in faucibus orci luctus et ultrices posuere cubilia curae; Aenean euismod.
+    </Txt>,
+  );
+
+  // Animate size and letter spacing to force recomputation paths that depend on
+  // correct font metrics and style propagation.
+  yield* waitFor(0.5);
+  yield* all(header().letterSpacing(3, 0.75), body().width(440, 0.75));
+  yield* all(header().letterSpacing(1.5, 0.75), body().width(520, 0.75));
+  yield* waitFor(0.5);
+});
+
+export const project = makeProject({
+  name: 'text_layout_properties',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/text_tween_font_ready.tsx
+++ b/packages/proximal-testing-videos/src/text_tween_font_ready.tsx
@@ -1,0 +1,67 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Txt, makeScene2D} from '@revideo/2d';
+import {createRef} from '@revideo/core';
+
+/**
+ * This scene verifies that text tweening accounts for font metrics by waiting
+ * for font readiness before measuring. Without the wait, intermediate sizes and
+ * interpolation paths differ, producing visual mismatches.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  const fontUrl = 'https://fonts.gstatic.com/s/robotoslab/v24/BngMUXZYTXPIvIBgJJSb6ufN5qU.woff2';
+  const ff = new FontFace('TestWebFont', `url(${fontUrl})`);
+  document.fonts.add(ff);
+  void ff.load();
+
+  view.fontFamily('TestWebFont, serif');
+  view.fontSize(56);
+  view.lineHeight('130%');
+  view.textWrap(true);
+  view.textAlign('left');
+
+  const t = createRef<Txt>();
+
+  view.add(
+    <Txt ref={t} width={560} letterSpacing={0.5}>
+      Start
+    </Txt>,
+  );
+
+  yield* waitFor(0.25);
+  // Tween text content. The implementation measures sizes before animating,
+  // and should wait for document.fonts.ready when fonts are loading.
+  yield* t().text('The quick brown fox jumps over the lazy dog', 1.2);
+  yield* waitFor(0.3);
+  yield* t().text('Pack my box with five dozen liquor jugs', 1.2);
+  yield* waitFor(0.5);
+});
+
+export const project = makeProject({
+  name: 'text_tween_font_ready',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Automated test plan for text-font-apply-and-fonts-ready:

- packages/proximal-testing-videos/src/text_font_loading_wait.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/text_layout_properties.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/text_tween_font_ready.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh