### PR TITLE
Add tests for txt-paint-style-inheritance

### DIFF
--- a/packages/proximal-testing-videos/src/txt_inheritance_dash.tsx
+++ b/packages/proximal-testing-videos/src/txt_inheritance_dash.tsx
@@ -1,0 +1,62 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
+
+/*
+  Purpose: Validates that nested <Txt> children inherit dashed stroke styles
+  (lineDash, lineDashOffset), as well as stroke and lineWidth.
+
+  Gold branch: children show dashed outlines identical to parent.
+  Removed-inheritance branch: children have no dashed stroke (default fill-only).
+*/
+
+const scene = makeScene2D('txt-inheritance-dash', function* (view) {
+  view.add(
+    <Rect
+      size={['100%', '100%']}
+      fill={'#ffffff'}
+      layout
+      alignItems={'center'}
+      justifyContent={'center'}
+    >
+      <Txt
+        fontSize={90}
+        fill={'#FFF59D'}
+        stroke={'#2E7D32'}
+        lineWidth={10}
+        lineDash={[14, 10]}
+        lineDashOffset={6}
+        fontFamily={'"JetBrains Mono", monospace'}
+      >
+        DASH <Txt>CHILD A</Txt> <Txt>CHILD B</Txt>
+      </Txt>
+    </Rect>,
+  );
+});
+
+export const project = makeProject({
+  name: 'txt_inheritance_dash',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/txt_inheritance_stroke.tsx
+++ b/packages/proximal-testing-videos/src/txt_inheritance_stroke.tsx
@@ -1,0 +1,60 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
+
+/*
+  Purpose: Validates that nested <Txt> children inherit paint styles
+  (fill, stroke, lineWidth) from their parent <Txt>.
+
+  Gold branch: children are outlined (stroke) and filled as parent.
+  Removed-inheritance branch: children render with default fill-only (no stroke).
+*/
+
+const scene = makeScene2D('txt-inheritance-stroke', function* (view) {
+  view.add(
+    <Rect
+      size={['100%', '100%']}
+      fill={'#ffffff'}
+      layout
+      alignItems={'center'}
+      justifyContent={'center'}
+    >
+      <Txt
+        fontSize={100}
+        fill={'#FFF59D'}
+        stroke={'#1565C0'}
+        lineWidth={12}
+        fontFamily={'"JetBrains Mono", monospace'}
+      >
+        PARENT <Txt>CHILD A</Txt> <Txt>CHILD B</Txt>
+      </Txt>
+    </Rect>,
+  );
+});
+
+export const project = makeProject({
+  name: 'txt_inheritance_stroke',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/txt_inheritance_stroke_first.tsx
+++ b/packages/proximal-testing-videos/src/txt_inheritance_stroke_first.tsx
@@ -1,0 +1,63 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
+
+/*
+  Purpose: Validates that nested <Txt> children inherit `strokeFirst` ordering
+  along with fill/stroke props.
+
+  Gold branch: children use stroke-first order (stroke under fill), producing
+  a softer outline.
+  Removed-inheritance branch: children render default fill-then-stroke or no
+  stroke at all (depending on other inheritance removals).
+*/
+
+const scene = makeScene2D('txt-inheritance-stroke-first', function* (view) {
+  view.add(
+    <Rect
+      size={['100%', '100%']}
+      fill={'#ffffff'}
+      layout
+      alignItems={'center'}
+      justifyContent={'center'}
+    >
+      <Txt
+        fontSize={96}
+        fill={'#FFECB3'}
+        stroke={'#C62828'}
+        lineWidth={14}
+        strokeFirst={true}
+        fontFamily={'"JetBrains Mono", monospace'}
+      >
+        ORDER <Txt>CHILD A</Txt> <Txt>CHILD B</Txt>
+      </Txt>
+    </Rect>,
+  );
+});
+
+export const project = makeProject({
+  name: 'txt_inheritance_stroke_first',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Automated test plan for txt-paint-style-inheritance:

- packages/proximal-testing-videos/src/txt_inheritance_stroke.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/txt_inheritance_dash.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/txt_inheritance_stroke_first.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh