### PR TITLE
Add tests for 2d-node-css-filters

### DIFF
--- a/packages/proximal-testing-videos/src/blur_bounds_motion.tsx
+++ b/packages/proximal-testing-videos/src/blur_bounds_motion.tsx
@@ -1,0 +1,61 @@
+import {makeProject, Vector2, waitFor, createRef} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {Gradient, blur} from '@revideo/2d';
+
+const W = 640;
+const H = 480;
+
+/**
+ * A moving blurred rect near edges to exercise blur-induced cache bbox expansion.
+ * Without blur support/expansion, edges appear hard or clipped; with it, soft edges extend.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  const fill = new Gradient({
+    type: 'linear',
+    from: [-80, -60],
+    to: [80, 60],
+    stops: [
+      {offset: 0, color: '#ff8a00'},
+      {offset: 1, color: '#8a00ff'},
+    ],
+  });
+
+  const r = createRef<Rect>();
+
+  view.add(
+    <Rect
+      ref={r}
+      size={[160, 120]}
+      position={[-W / 2 + 100, 0]}
+      fill={fill}
+      filters={[blur(10)]}
+    />,
+  );
+
+  // Move horizontally across the screen, including near edges.
+  yield* r().x(W / 2 - 100, 1.5);
+  yield* r().x(-W / 2 + 100, 1.5);
+  yield* waitFor(0.5);
+});
+
+export const project = makeProject({
+  name: 'blur_bounds_motion',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 4],
+      size: new Vector2(W, H),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/filters_animated_cycle.tsx
+++ b/packages/proximal-testing-videos/src/filters_animated_cycle.tsx
@@ -1,0 +1,102 @@
+import {makeProject, Vector2, all, waitFor} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {Gradient, blur, brightness, contrast, grayscale, hue, invert, saturate} from '@revideo/2d';
+
+const W = 640;
+const H = 480;
+
+/**
+ * Animates through a cycle of filters on a single rect.
+ * Each filter animates over ~0.5s, then resets before the next one.
+ * Validates filter signal animation behavior and serialization over time.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  const fill = new Gradient({
+    type: 'linear',
+    from: [-160, -120],
+    to: [160, 120],
+    stops: [
+      {offset: 0, color: '#ff0000'},
+      {offset: 0.5, color: '#00ff00'},
+      {offset: 1, color: '#0000ff'},
+    ],
+  });
+
+  const fInvert = invert(0);
+  const fGray = grayscale(0);
+  const fBright = brightness(1);
+  const fContrast = contrast(1);
+  const fSaturate = saturate(1);
+  const fHue = hue(0);
+  const fBlur = blur(0);
+
+  view.add(
+    <Rect
+      size={[320, 240]}
+      fill={fill}
+      lineWidth={2}
+      stroke={'#222'}
+      filters={[fInvert, fGray, fBright, fContrast, fSaturate, fHue, fBlur]}
+    />,
+  );
+
+  // Invert 0 -> 1
+  yield* fInvert.value(1, 0.5);
+  yield* waitFor(0.2);
+  fInvert.value(0);
+
+  // Grayscale 0 -> 1
+  yield* fGray.value(1, 0.5);
+  yield* waitFor(0.2);
+  fGray.value(0);
+
+  // Brightness 1 -> 1.8
+  yield* fBright.value(1.8, 0.5);
+  yield* waitFor(0.2);
+  fBright.value(1);
+
+  // Contrast 1 -> 1.8
+  yield* fContrast.value(1.8, 0.5);
+  yield* waitFor(0.2);
+  fContrast.value(1);
+
+  // Saturate 1 -> 1.8
+  yield* fSaturate.value(1.8, 0.5);
+  yield* waitFor(0.2);
+  fSaturate.value(1);
+
+  // Hue 0 -> 180
+  yield* fHue.value(180, 0.5);
+  yield* waitFor(0.2);
+  fHue.value(0);
+
+  // Blur 0 -> 10
+  yield* fBlur.value(10, 0.5);
+  yield* waitFor(0.3);
+  fBlur.value(0);
+
+  // Hold briefly to ensure deterministic end.
+  yield* waitFor(0.3);
+});
+
+export const project = makeProject({
+  name: 'filters_animated_cycle',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 5],
+      size: new Vector2(W, H),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/filters_static_grid.tsx
+++ b/packages/proximal-testing-videos/src/filters_static_grid.tsx
@@ -1,0 +1,73 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {Gradient, blur, brightness, contrast, grayscale, hue, invert, saturate} from '@revideo/2d';
+
+const W = 640;
+const H = 480;
+
+/**
+ * A static grid showcasing each filter applied to the same gradient rect.
+ * Useful to validate filter serialization and visual output.
+ */
+export const scene = makeScene2D('scene', function* (view) {
+  const baseFill = new Gradient({
+    type: 'linear',
+    from: [-160, -120],
+    to: [160, 120],
+    stops: [
+      {offset: 0, color: '#ff0000'},
+      {offset: 0.5, color: '#00ff00'},
+      {offset: 1, color: '#0000ff'},
+    ],
+  });
+
+  type Item = {x: number; y: number; label: string; filters: any[]};
+  const items: Item[] = [
+    {x: -200, y: -140, label: 'none', filters: []},
+    {x: 0, y: -140, label: 'invert', filters: [invert(1)]},
+    {x: 200, y: -140, label: 'grayscale', filters: [grayscale(1)]},
+    {x: -200, y: 0, label: 'brightness', filters: [brightness(1.6)]},
+    {x: 0, y: 0, label: 'contrast', filters: [contrast(1.8)]},
+    {x: 200, y: 0, label: 'saturate', filters: [saturate(1.8)]},
+    {x: -100, y: 140, label: 'hue-rotate', filters: [hue(180)]},
+    {x: 100, y: 140, label: 'blur', filters: [blur(8)]},
+  ];
+
+  for (const it of items) {
+    view.add(
+      <Rect
+        position={[it.x, it.y]}
+        size={[180, 120]}
+        fill={baseFill}
+        lineWidth={2}
+        stroke={'#222'}
+        filters={it.filters}
+      />,
+    );
+  }
+
+  // Hold for a short, fixed duration for deterministic render.
+  yield* waitFor(2);
+});
+
+export const project = makeProject({
+  name: 'filters_static_grid',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 2],
+      size: new Vector2(W, H),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Automated test plan for 2d-node-css-filters:

- packages/proximal-testing-videos/src/filters_static_grid.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
- packages/proximal-testing-videos/src/filters_animated_cycle.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/blur_bounds_motion.tsx: packages-proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh