### PR TITLE
Add tests for 2d-node-child-clipping

### DIFF
--- a/packages/proximal-testing-videos/src/clip_img_children.tsx
+++ b/packages/proximal-testing-videos/src/clip_img_children.tsx
@@ -1,0 +1,42 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Img, Rect, makeScene2D} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  yield view.add(<Rect size={[640, 480]} fill={'#ffffff'} />);
+
+  const parent = (
+    <Img
+      size={[240, 160]}
+      clip={true}
+      src={'https://revideo-example-assets.s3.amazonaws.com/revideo-logo-white.png'}
+    />
+  );
+  yield view.add(parent);
+
+  // Child overflow rectangle that should be masked by Img when clip is true
+  parent.add(
+    <Rect size={[360, 80]} fill={'#4caf50'} position={[0, 0]} />,
+  );
+});
+
+export const project = makeProject({
+  name: 'clip_img_children',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/clip_layout_children.tsx
+++ b/packages/proximal-testing-videos/src/clip_layout_children.tsx
@@ -1,0 +1,53 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Layout, Rect, makeScene2D} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  // Centered parent layout with clipping enabled
+  const parent = (
+    <Layout
+      size={[220, 160]}
+      position={[0, 0]}
+      clip={true}
+      layout={false}
+    />
+  );
+
+  yield view.add(
+    <>
+      {/* Background to make overflow clearly visible */}
+      <Rect size={[640, 480]} fill={'#ffffff'} />
+      {parent}
+    </>,
+  );
+
+  // Add a large child that overflows the parent bounds on all sides
+  parent.add(
+    <Rect
+      size={[360, 120]}
+      fill={'#e91e63'}
+      position={[0, 0]}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'clip_layout_children',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/clip_shape_children.tsx
+++ b/packages/proximal-testing-videos/src/clip_shape_children.tsx
@@ -1,0 +1,40 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  // Background to visualize overflow
+  yield view.add(<Rect size={[640, 480]} fill={'#ffffff'} />);
+
+  // Parent shape (Rect) with child clipping enabled
+  const parent = (
+    <Rect size={[240, 180]} fill={'#bdbdbd'} clip={true} />
+  );
+  yield view.add(parent);
+
+  // Child that overflows outside the parent's rounded rectangle
+  parent.add(
+    <Rect size={[360, 80]} fill={'#2196f3'} position={[0, 0]} />,
+  );
+});
+
+export const project = makeProject({
+  name: 'clip_shape_children',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/clip_video_children.tsx
+++ b/packages/proximal-testing-videos/src/clip_video_children.tsx
@@ -1,0 +1,43 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Video, makeScene2D} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  yield view.add(<Rect size={[640, 480]} fill={'#ffffff'} />);
+
+  const parent = (
+    <Video
+      size={[260, 160]}
+      clip={true}
+      play={false}
+      src={'https://revideo-example-assets.s3.amazonaws.com/stars.mp4'}
+    />
+  );
+  yield view.add(parent);
+
+  // Overflow child; should be masked by Video when clip is true
+  parent.add(
+    <Rect size={[380, 90]} fill={'#ffeb3b'} position={[0, 0]} />,
+  );
+});
+
+export const project = makeProject({
+  name: 'clip_video_children',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {fps: 30, resolutionScale: 1},
+    rendering: {
+      exporter: {name: '@revideo/core/ffmpeg', options: {format: 'mp4'}},
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/render.js
+++ b/packages/proximal-testing-videos/src/render.js
@@ -1,0 +1,27 @@
+// Lightweight JS wrapper to render a project file via @revideo/renderer
+async function main() {
+  const {renderVideo} = require('@revideo/renderer');
+  const projectFile = process.argv[2] || './src/project.ts';
+  const outFile = process.argv[3] || 'video.mp4';
+
+  console.log(`Rendering video using ${projectFile} -> ${outFile}...`);
+  const file = await renderVideo({
+    projectFile,
+    settings: {
+      logProgress: true,
+      outFile,
+      puppeteer: {
+        executablePath: '/usr/bin/chromium',
+        args: ['--no-sandbox', '--disable-dev-shm-usage', '--single-process'],
+        headless: true,
+      },
+    },
+  });
+  console.log(`Rendered video to ${file}`);
+}
+
+main().catch(err => {
+  console.error(err);
+  process.exit(1);
+});
+

--- a/packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Renders the same project file on two branches and compares outputs.
+# Usage: compare_across_branches.sh <project_rel_path> <gold_branch> <test_branch>
+
+if [[ $# -lt 3 ]]; then
+  echo "Usage: $0 <project_rel_path> <gold_branch> <test_branch>" >&2
+  exit 2
+fi
+
+PROJECT="$1"
+GOLD_BRANCH="$2"
+TEST_BRANCH="$3"
+
+ROOT_DIR=$(git rev-parse --show-toplevel)
+OUT_DIR="$ROOT_DIR/.tmp-clip-tests"
+mkdir -p "$OUT_DIR"
+
+build_all() {
+  npm run core:build
+  npm run 2d:build
+  npm run renderer:build
+}
+
+render() {
+  local project_file="$1"
+  local out_file="$2"
+  node packages/proximal-testing-videos/src/render.js "$project_file" "$out_file"
+}
+
+git checkout "$GOLD_BRANCH"
+build_all
+render "$PROJECT" "$OUT_DIR/gold.mp4"
+
+git checkout "$TEST_BRANCH"
+build_all
+render "$PROJECT" "$OUT_DIR/test.mp4"
+
+bash packages/proximal-testing-videos/src/testing_scripts/compare_videos_ssim.sh \
+  "$OUT_DIR/gold.mp4" "$OUT_DIR/test.mp4" 1.0
+
+echo "Videos match for $PROJECT across $GOLD_BRANCH vs $TEST_BRANCH"
+

--- a/packages/proximal-testing-videos/src/testing_scripts/compare_videos_ssim.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/compare_videos_ssim.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <video_a> <video_b> [threshold]" >&2
+  echo "Compares two videos with SSIM and duration; exits non-zero if different." >&2
+  exit 2
+fi
+
+VIDEO_A="$1"
+VIDEO_B="$2"
+THRESHOLD="${3:-1.0}"
+
+if [[ ! -f "$VIDEO_A" || ! -f "$VIDEO_B" ]]; then
+  echo "Video files not found: $VIDEO_A or $VIDEO_B" >&2
+  exit 3
+fi
+
+# Compare durations (in seconds, rounded to milliseconds)
+duration_a=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_A")
+duration_b=$(ffprobe -v error -show_entries format=duration -of default=noprint_wrappers=1:nokey=1 "$VIDEO_B")
+
+ms_a=$(python - <<PY
+import math
+print(int(round(float("$duration_a")*1000)))
+PY
+)
+ms_b=$(python - <<PY
+import math
+print(int(round(float("$duration_b")*1000)))
+PY
+)
+
+if [[ "$ms_a" -ne "$ms_b" ]]; then
+  echo "Duration mismatch: ${ms_a}ms vs ${ms_b}ms" >&2
+  exit 4
+fi
+
+# Compute SSIM
+ssim_line=$(ffmpeg -v error -i "$VIDEO_A" -i "$VIDEO_B" -lavfi ssim -f null - 2>&1 | tail -n 1 || true)
+# Expected format: SSIM Y:1.000000 U:... All:0.9999 (assuming)
+all_ssim=$(echo "$ssim_line" | sed -n 's/.*All:\([0-9.]*\).*/\1/p')
+
+if [[ -z "$all_ssim" ]]; then
+  echo "Could not parse SSIM output: $ssim_line" >&2
+  exit 5
+fi
+
+echo "SSIM(All) = $all_ssim"
+
+awk -v s="$all_ssim" -v t="$THRESHOLD" 'BEGIN { exit !(s>=t) }'
+

--- a/packages/proximal-testing-videos/src/testing_scripts/test_clip_img_children.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/test_clip_img_children.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <gold_branch> <test_branch>" >&2
+  exit 2
+fi
+
+GOLD_BRANCH="$1"
+TEST_BRANCH="$2"
+
+bash packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh \
+  packages/proximal-testing-videos/src/clip_img_children.tsx \
+  "$GOLD_BRANCH" "$TEST_BRANCH"
+

--- a/packages/proximal-testing-videos/src/testing_scripts/test_clip_layout_children.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/test_clip_layout_children.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <gold_branch> <test_branch>" >&2
+  exit 2
+fi
+
+GOLD_BRANCH="$1"
+TEST_BRANCH="$2"
+
+bash packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh \
+  packages/proximal-testing-videos/src/clip_layout_children.tsx \
+  "$GOLD_BRANCH" "$TEST_BRANCH"
+

--- a/packages/proximal-testing-videos/src/testing_scripts/test_clip_shape_children.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/test_clip_shape_children.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <gold_branch> <test_branch>" >&2
+  exit 2
+fi
+
+GOLD_BRANCH="$1"
+TEST_BRANCH="$2"
+
+bash packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh \
+  packages/proximal-testing-videos/src/clip_shape_children.tsx \
+  "$GOLD_BRANCH" "$TEST_BRANCH"
+

--- a/packages/proximal-testing-videos/src/testing_scripts/test_clip_video_children.sh
+++ b/packages/proximal-testing-videos/src/testing_scripts/test_clip_video_children.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "Usage: $0 <gold_branch> <test_branch>" >&2
+  exit 2
+fi
+
+GOLD_BRANCH="$1"
+TEST_BRANCH="$2"
+
+bash packages/proximal-testing-videos/src/testing_scripts/compare_across_branches.sh \
+  packages/proximal-testing-videos/src/clip_video_children.tsx \
+  "$GOLD_BRANCH" "$TEST_BRANCH"
+


### PR DESCRIPTION
Automated test plan for 2d-node-child-clipping:

- packages/proximal-testing-videos/src/clip_layout_children.tsx: packages/proximal-testing-videos/src/testing_scripts/test_clip_layout_children.sh
- packages/proximal-testing-videos/src/clip_shape_children.tsx: packages/proximal-testing-videos/src/testing_scripts/test_clip_shape_children.sh
- packages/proximal-testing-videos/src/clip_img_children.tsx: packages/proximal-testing-videos/src/testing_scripts/test_clip_img_children.sh
- packages/proximal-testing-videos/src/clip_video_children.tsx: packages/proximal-testing-videos/src/testing_scripts/test_clip_video_children.sh