### PR TITLE
Add tests for rounded-rect-smooth-corners

### DIFF
--- a/packages/proximal-testing-videos/src/round_rect_large_radius_adjust.tsx
+++ b/packages/proximal-testing-videos/src/round_rect_large_radius_adjust.tsx
@@ -1,0 +1,48 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.fill('#ffffff');
+
+  // Intentional large radius to trigger adjustRectRadius logic
+  yield view.add(
+    <Rect
+      width={300}
+      height={150}
+      radius={200}
+      fill={'#e67e22'}
+      stroke={'#a85911'}
+      lineWidth={4}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'round-rect-large-radius-adjust',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/round_rect_per_corner.tsx
+++ b/packages/proximal-testing-videos/src/round_rect_per_corner.tsx
@@ -1,0 +1,47 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.fill('#ffffff');
+
+  yield view.add(
+    <Rect
+      width={380}
+      height={240}
+      radius={[10, 30, 50, 70]}
+      fill={'#3498db'}
+      stroke={'#226a96'}
+      lineWidth={4}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'round-rect-per-corner',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/round_rect_smooth.tsx
+++ b/packages/proximal-testing-videos/src/round_rect_smooth.tsx
@@ -1,0 +1,49 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.fill('#ffffff');
+
+  yield view.add(
+    <Rect
+      width={360}
+      height={220}
+      radius={80}
+      smoothCorners={true}
+      cornerSharpness={0.25}
+      fill={'#9b59b6'}
+      stroke={'#6d3d82'}
+      lineWidth={4}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'round-rect-smooth',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/round_rect_uniform.tsx
+++ b/packages/proximal-testing-videos/src/round_rect_uniform.tsx
@@ -1,0 +1,47 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.fill('#ffffff');
+
+  yield view.add(
+    <Rect
+      width={320}
+      height={200}
+      radius={40}
+      fill={'#2ecc71'}
+      stroke={'#1e874b'}
+      lineWidth={4}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'round-rect-uniform',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Automated test plan for rounded-rect-smooth-corners:

- packages/proximal-testing-videos/src/round_rect_uniform.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/round_rect_per_corner.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/round_rect_smooth.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/round_rect_large_radius_adjust.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh