### PR TITLE
Add environment for 2d-node-child-clipping

### DIFF
--- a/environments/revideo-2d-node-child-clipping/revideo-2d-node-child-clipping.env.ts
+++ b/environments/revideo-2d-node-child-clipping/revideo-2d-node-child-clipping.env.ts
@@ -1,0 +1,299 @@
+import { Environment } from "../../proximal/core/environment";
+import { RepoContainer } from "../../proximal/core/container/RepoContainer";
+import { TaskRunnerAgent } from "../../proximal/core/agents/TaskRunnerAgent";
+import repos from "../../repos/repos";
+
+const TASK_ID = "2d-node-child-clipping";
+
+export const revideo2dNodeChildClippingEnvironment = new Environment({
+  id: `revideo-2d-node-child-clipping`,
+  name: `revideo-2d-node-child-clipping`,
+  description: `revideo-2d-node-child-clipping`,
+  codebase: "Revideo",
+  task: `revideo-2d-node-child-clipping`,
+  repoPath: repos.revideo.path,
+
+  setupEnvironment: async (container: RepoContainer) => {
+    console.log("🔧 Setting up Revideo environment...");
+
+    await container.exec({
+      command: "git fetch origin",
+      stream: true,
+    });
+
+    console.log("📍 Checking out latest base branch...");
+    await container.exec({
+      command: "git fetch origin 2d-node-child-clipping-base && git checkout 2d-node-child-clipping-base && git pull origin 2d-node-child-clipping-base",
+      stream: true,
+    });
+
+    console.log("📦 Installing dependencies...");
+    await container.exec({
+      command: "npm install",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.resetDiffBaseline();
+
+    console.log("✅ Environment setup completed");
+  },
+
+  variants: {
+    "Difficult Prompt": async (container: RepoContainer, agent: TaskRunnerAgent) => {
+      console.log("🧠 Running difficult prompt variant...");
+
+      await agent.run(
+        `Removed node-level child clipping controlled by the clip property across 2D components (Layout, Shape, Img, Video, Rive). Previously, a node set a canvas clipping path so its children were masked to the node’s path/rectangle; this is no longer applied. Rendering change: child overflow is now visible—containers no longer hide overflow—so exported/rendered videos may show content (e.g., text/images) spilling beyond parent bounds. Media elements may still mask their own pixels to their shapes, but they no longer establish a clip for subsequent children.`
+      );
+    },
+  },
+
+  setupTests: async (container: RepoContainer) => {
+    console.log("🧪 Setting up test environment...");
+
+    await container.exec({
+      command: "bash -lc 'git add -A && git stash push -u -m "agent-changes" || true'",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git restore --source origin/testing-branch -- packages/proximal-testing-videos",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-node-child-clipping-solution",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/clip_layout_children.tsx clip_layout_children_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/clip_shape_children.tsx clip_shape_children_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/clip_img_children.tsx clip_img_children_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/clip_video_children.tsx clip_video_children_baseline.mp4",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-node-child-clipping-base",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git stash pop || true",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    console.log("✅ Test setup completed");
+  },
+
+  tests: [
+    {
+      id: "compiles-correctly",
+      name: "Correctly compiles?",
+      description: "Test that code compiles correctly",
+      test: async (container: RepoContainer) => {
+        console.log("  Testing compile step...");
+        try {
+          const result = await container.exec({
+            command: "npx lerna run build --skip-nx-cache",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const exitCode = typeof result === "string" ? 0 : result.exitCode;
+          return exitCode === 0;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+    {
+      id: "2d-node-child-clipping-1",
+      name: "Validate clip_layout_children",
+      description: "Render baseline and solution for clip_layout_children and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/clip_layout_children.tsx clip_layout_children_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/src/testing_scripts/test_clip_layout_children.sh packages/proximal-testing-videos/output/clip_layout_children_baseline.mp4 packages/proximal-testing-videos/output/clip_layout_children_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-node-child-clipping-2",
+      name: "Validate clip_shape_children",
+      description: "Render baseline and solution for clip_shape_children and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/clip_shape_children.tsx clip_shape_children_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/src/testing_scripts/test_clip_shape_children.sh packages/proximal-testing-videos/output/clip_shape_children_baseline.mp4 packages/proximal-testing-videos/output/clip_shape_children_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-node-child-clipping-3",
+      name: "Validate clip_img_children",
+      description: "Render baseline and solution for clip_img_children and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/clip_img_children.tsx clip_img_children_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/src/testing_scripts/test_clip_img_children.sh packages/proximal-testing-videos/output/clip_img_children_baseline.mp4 packages/proximal-testing-videos/output/clip_img_children_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-node-child-clipping-4",
+      name: "Validate clip_video_children",
+      description: "Render baseline and solution for clip_video_children and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/clip_video_children.tsx clip_video_children_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/src/testing_scripts/test_clip_video_children.sh packages/proximal-testing-videos/output/clip_video_children_baseline.mp4 packages/proximal-testing-videos/output/clip_video_children_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    }
+  ],
+
+  prompt: `${environmentPrompt}`,
+  branches: {
+    base: "2d-node-child-clipping-base",
+    solution: "2d-node-child-clipping-solution",
+    diff: "https://github.com/Proximal-Labs/task-demo-revideo/compare/2d-node-child-clipping-base...2d-node-child-clipping-solution",
+    testingPr: "https://github.com/Proximal-Environments/revideo-env/pull/16",
+    environmentPr: "",
+  },
+});
+
+export default revideo2dNodeChildClippingEnvironment;


### PR DESCRIPTION
This PR adds the generated environment file for **2d-node-child-clipping**.

- Base branch (feature removed): https://github.com/Proximal-Labs/task-demo-revideo/tree/2d-node-child-clipping-base
- Solution branch (feature restored): https://github.com/Proximal-Labs/task-demo-revideo/tree/2d-node-child-clipping-solution
- Feature diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/2d-node-child-clipping-base...2d-node-child-clipping-solution
- Testing PR: https://github.com/Proximal-Environments/revideo-env/pull/16