### PR TITLE
Add tests for media-shape-masking

### DIFF
--- a/packages/proximal-testing-videos/src/img_rounded_corners.tsx
+++ b/packages/proximal-testing-videos/src/img_rounded_corners.tsx
@@ -1,0 +1,54 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Img, Rect, makeScene2D} from '@revideo/2d';
+
+// Purpose: verifies that Img pixels are clipped to the node's rounded-rect path.
+// Expected difference when clipping is removed: image pixels remain visible in the
+// rounded corners (spilling outside the intended mask), causing visible changes at the corners.
+
+export const scene = makeScene2D('scene', function* (view) {
+  // High-contrast background to make corner spill obvious
+  view.add(<Rect fill={'#ffffff'} size={['100%', '100%']} />);
+
+  // Use a colorful remote image so corner spill is clearly visible
+  view.add(
+    <Img
+      src={'https://images.unsplash.com/photo-1679218407381-a6f1660d60e9?w=960&q=80&auto=format'}
+      width={480}
+      height={360}
+      radius={80}
+      lineWidth={6}
+      stroke={'#ff0000'}
+      smoothing={true}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'img_rounded_corners',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/video_rounded_corners.tsx
+++ b/packages/proximal-testing-videos/src/video_rounded_corners.tsx
@@ -1,0 +1,55 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Video, makeScene2D} from '@revideo/2d';
+
+// Purpose: verifies that Video pixels are clipped to the node's rounded-rect path.
+// Expected difference when clipping is removed: video pixels remain visible in the
+// rounded corners (spilling outside the intended mask), causing visible changes at the corners.
+
+export const scene = makeScene2D('scene', function* (view) {
+  // High-contrast background to make corner spill obvious
+  view.add(<Rect fill={'#ffffff'} size={['100%', '100%']} />);
+
+  // Place a video with large corner radius; content should be masked to rounded rect
+  view.add(
+    <Video
+      src={'https://revideo-example-assets.s3.amazonaws.com/stars.mp4'}
+      width={480}
+      height={360}
+      radius={80}
+      lineWidth={6}
+      stroke={'#ff0000'}
+      play={false}
+      time={1.2}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'video_rounded_corners',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
# Feature Removal Session session-mgd5ghmp-6f06fb77

## Summary
- Total features: 1
- Testing branch: testing-branch-session-mgd5ghmp-6f06fb77
- Environment branch prefix: environments-session-mgd5ghmp-6f06fb77
- Base testing branch: testing-branch

## Features

### media-shape-masking
Removed clipping of Img and Video pixels to their node’s shape path (e.g., rounded rectangles). Media is no longer masked to shapes and now renders as full rectangles. When rendering videos, rounded corners and non-rectangular masks are ignored, so video frames can spill outside the shape and no longer conform to strokes or radii.

- Branches:
  - Base: testing-branch-session-mgd5ghmp-6f06fb77-env-media-shape-masking
  - Solution: testing-branch-session-mgd5ghmp-6f06fb77-env-media-shape-masking-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5ghmp-6f06fb77-env-media-shape-masking...testing-branch-session-mgd5ghmp-6f06fb77-env-media-shape-masking-solution
- Testing PRs:
  - Tests: https://github.com/Proximal-Environments/revideo-env/pull/22
- Environment:
  - Branch: environments-session-mgd5ghmp-6f06fb77-media-shape-masking
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/23
- Tests:
  - packages/proximal-testing-videos/src/video_rounded_corners.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/img_rounded_corners.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh