### PR TITLE
Add tests for curve-arrowheads

### DIFF
--- a/packages/proximal-testing-videos/src/curve_arrows_both_size.tsx
+++ b/packages/proximal-testing-videos/src/curve_arrows_both_size.tsx
@@ -1,0 +1,44 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Line, makeScene2D} from '@revideo/2d';
+
+// Static scene showing a diagonal line with both start and end arrows, custom size.
+const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Line
+      points={[[-180, -120], [180, 120]]}
+      stroke={'#1a73e8'}
+      lineWidth={12}
+      startArrow
+      endArrow
+      arrowSize={44}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'curve_arrows_both_size',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/curve_arrows_end_only.tsx
+++ b/packages/proximal-testing-videos/src/curve_arrows_end_only.tsx
@@ -1,0 +1,43 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Line, makeScene2D} from '@revideo/2d';
+
+// Static scene showing a horizontal line with an end arrow.
+const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Line
+      points={[[-220, 0], [220, 0]]}
+      stroke={'#000000'}
+      lineWidth={14}
+      endArrow
+      arrowSize={36}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'curve_arrows_end_only',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/curve_arrows_ray.tsx
+++ b/packages/proximal-testing-videos/src/curve_arrows_ray.tsx
@@ -1,0 +1,44 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Ray, makeScene2D} from '@revideo/2d';
+
+// Static scene showing a ray with an end arrow.
+const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Ray
+      from={[-160, 60]}
+      to={[220, 60]}
+      stroke={'#e53935'}
+      lineWidth={10}
+      endArrow
+      arrowSize={28}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'curve_arrows_ray',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, 2],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
# Feature Removal Session session-mgd5w8xe-2a433b3b

## Summary
- Total features: 4
- Testing branch: testing-branch-session-mgd5w8xe-2a433b3b
- Environment branch prefix: environments-session-mgd5w8xe-2a433b3b
- Base testing branch: testing-branch

## Features

### 2d-gradient-fills-and-strokes
Removed the Gradient canvas style from the 2D renderer (linear/conic/radial). Gradient objects are no longer accepted in fill/stroke styles—only solid colors and patterns remain. When rendering/exporting videos, any shapes that previously used gradients will no longer display gradient transitions and will instead render with flat colors (or missing fill/stroke if no color fallback), altering the visual appearance of those scenes.

- Branches:
  - Base: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes
  - Solution: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution
- Environment:
  - Branch: environments-session-mgd5w8xe-2a433b3b-2d-gradient-fills-and-strokes
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/27
- Tests:
  - packages/proximal-testing-videos/src/gradient_conic.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
  - packages/proximal-testing-videos/src/gradient_linear.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
  - packages/proximal-testing-videos/src/gradient_radial.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
  - packages/proximal-testing-videos/src/gradient_stroke_linear.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh

### 2d-node-drop-shadows
Removed drop shadow support on 2D nodes (shadowColor, shadowBlur, shadowOffset/XY). Shadow rendering and related cache/bounding-box expansion were deleted. When rendering/exporting frames or videos, nodes will no longer show drop shadows; any shadow properties now have no effect (and may produce type errors in strict builds).

- Branches:
  - Base: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows
  - Solution: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution
- Environment:
  - Branch: environments-session-mgd5w8xe-2a433b3b-2d-node-drop-shadows
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/26
- Tests:
  - packages/proximal-testing-videos/src/shadow_rect.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/shadow_animated.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/shadow_text_image.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh

### 2d-stroke-rendering
Removed stroke drawing for 2D shapes and text. Shapes no longer call context.stroke, text uses fillText only, and curve arrowheads (stroke-based) are not drawn. In rendered videos, outlines/borders and dashed strokes no longer appear—only fills are visible, and stroke-related properties (color, width, order) have no effect.

- Branches:
  - Base: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering
  - Solution: testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution
- Environment:
  - Branch: environments-session-mgd5w8xe-2a433b3b-2d-stroke-rendering
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/28
- Tests:
  - packages/proximal-testing-videos/src/stroke_rects.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/dashed_line.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/text_stroke.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/curve_arrowheads.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh

### curve-arrowheads
Removed support for start/end arrowheads on 2D curves. The engine no longer computes arrow size, adjusts curve endpoints, expands the bounding box, or draws arrowheads—startArrow/endArrow are effectively ignored. When rendering videos, curves that previously displayed arrow tips will now render without any arrowheads.

- Branches:
  - Base: testing-branch-session-mgd5w8xe-2a433b3b-env-curve-arrowheads
  - Solution: testing-branch-session-mgd5w8xe-2a433b3b-env-curve-arrowheads-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-curve-arrowheads...testing-branch-session-mgd5w8xe-2a433b3b-env-curve-arrowheads-solution
- Testing PRs:
  - Tests: https://github.com/Proximal-Environments/revideo-env/pull/24
- Environment:
  - Branch: environments-session-mgd5w8xe-2a433b3b-curve-arrowheads
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/25
- Tests:
  - packages/proximal-testing-videos/src/curve_arrows_end_only.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
  - packages/proximal-testing-videos/src/curve_arrows_both_size.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
  - packages/proximal-testing-videos/src/curve_arrows_ray.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh