### PR TITLE
Add environment for 2d-node-drop-shadows

### DIFF
--- a/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
+++ b/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
@@ -1,0 +1,2 @@
+import 2d-node-drop-shadowsEnvironment from "../environments/revideo-2d-node-drop-shadows/revideo-2d-node-drop-shadows.env";
+cat: /root/workspace/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts: No such file or directory

--- a/environments/revideo-2d-node-drop-shadows/revideo-2d-node-drop-shadows.env.ts
+++ b/environments/revideo-2d-node-drop-shadows/revideo-2d-node-drop-shadows.env.ts
@@ -1,0 +1,261 @@
+import { Environment } from "../../proximal/core/environment";
+import { RepoContainer } from "../../proximal/core/container/RepoContainer";
+import { TaskRunnerAgent } from "../../proximal/core/agents/TaskRunnerAgent";
+import repos from "../../repos/repos";
+
+const TASK_ID = "2d-node-drop-shadows";
+
+export const revideo2dNodeDropShadowsEnvironment = new Environment({
+  id: `revideo-2d-node-drop-shadows`,
+  name: `revideo-2d-node-drop-shadows`,
+  description: `revideo-2d-node-drop-shadows`,
+  codebase: "Revideo",
+  task: `revideo-2d-node-drop-shadows`,
+  repoPath: repos.revideo.path,
+
+  setupEnvironment: async (container: RepoContainer) => {
+    console.log("🔧 Setting up Revideo environment...");
+
+    await container.exec({
+      command: "git fetch origin",
+      stream: true,
+    });
+
+    console.log("📍 Checking out latest base branch...");
+    await container.exec({
+      command: "git fetch origin 2d-node-drop-shadows-base && git checkout 2d-node-drop-shadows-base && git pull origin 2d-node-drop-shadows-base",
+      stream: true,
+    });
+
+    console.log("📦 Installing dependencies...");
+    await container.exec({
+      command: "npm install",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.resetDiffBaseline();
+
+    console.log("✅ Environment setup completed");
+  },
+
+  variants: {
+    "Difficult Prompt": async (container: RepoContainer, agent: TaskRunnerAgent) => {
+      console.log("🧠 Running difficult prompt variant...");
+
+      await agent.run(
+        `Removed drop shadow support on 2D nodes (shadowColor, shadowBlur, shadowOffset/XY). Shadow rendering and related cache/bounding-box expansion were deleted. When rendering/exporting frames or videos, nodes will no longer show drop shadows; any shadow properties now have no effect (and may produce type errors in strict builds).`
+      );
+    },
+  },
+
+  setupTests: async (container: RepoContainer) => {
+    console.log("🧪 Setting up test environment...");
+
+    await container.exec({
+      command: "bash -lc 'git add -A && git stash push -u -m "agent-changes" || true'",
+      stream: true,
+    });
+
+    await container.exec({
+      command: `git restore --source origin/${summary.testBranch} -- packages/proximal-testing-videos`,
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-node-drop-shadows-solution",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/shadow_rect.tsx shadow_rect_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/shadow_animated.tsx shadow_animated_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/shadow_text_image.tsx shadow_text_image_baseline.mp4",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-node-drop-shadows-base",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git stash pop || true",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    console.log("✅ Test setup completed");
+  },
+
+  tests: [
+    {
+      id: "compiles-correctly",
+      name: "Correctly compiles?",
+      description: "Test that code compiles correctly",
+      test: async (container: RepoContainer) => {
+        console.log("  Testing compile step...");
+        try {
+          const result = await container.exec({
+            command: "npx lerna run build --skip-nx-cache",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const exitCode = typeof result === "string" ? 0 : result.exitCode;
+          return exitCode === 0;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+    {
+      id: "2d-node-drop-shadows-1",
+      name: "Validate shadow_rect",
+      description: "Render baseline and solution for shadow_rect and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/shadow_rect.tsx shadow_rect_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/shadow_rect_baseline.mp4 packages/proximal-testing-videos/output/shadow_rect_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/shadow_rect_baseline.mp4 packages/proximal-testing-videos/output/shadow_rect_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-node-drop-shadows-2",
+      name: "Validate shadow_animated",
+      description: "Render baseline and solution for shadow_animated and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/shadow_animated.tsx shadow_animated_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/shadow_animated_baseline.mp4 packages/proximal-testing-videos/output/shadow_animated_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/shadow_animated_baseline.mp4 packages/proximal-testing-videos/output/shadow_animated_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-node-drop-shadows-3",
+      name: "Validate shadow_text_image",
+      description: "Render baseline and solution for shadow_text_image and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/shadow_text_image.tsx shadow_text_image_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/shadow_text_image_baseline.mp4 packages/proximal-testing-videos/output/shadow_text_image_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/shadow_text_image_baseline.mp4 packages/proximal-testing-videos/output/shadow_text_image_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    }
+  ],
+
+  prompt: `${environmentPrompt}`,
+  branches: {
+    base: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows",
+    solution: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution",
+    diff: "https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution",
+    testingPr: "",
+    environmentPr: "",
+  },
+});
+
+export default revideo2dNodeDropShadowsEnvironment;

--- a/packages/proximal-testing-videos/src/shadow_animated.tsx
+++ b/packages/proximal-testing-videos/src/shadow_animated.tsx
@@ -1,0 +1,57 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+import {createRef, waitFor} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  const rect = createRef<Rect>();
+
+  view.add(
+    <Rect
+      ref={rect}
+      x={0}
+      y={0}
+      width={240}
+      height={160}
+      fill={'#E74C3C'}
+      radius={20}
+      shadowColor={'rgba(50,50,50,0.9)'}
+      shadowBlur={30}
+      shadowOffset={{x: -40, y: -10}}
+    />,
+  );
+
+  // Animate the shadow offset to ensure dynamic shadow rendering works.
+  yield* waitFor(0.2);
+  yield* rect().shadowOffset({x: 40, y: 25}, 0.8);
+  yield* rect().shadowOffset({x: 0, y: 0}, 0.6);
+  yield* waitFor(0.2);
+});
+
+export const project = makeProject({
+  name: 'shadow-animated',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/shadow_rect.tsx
+++ b/packages/proximal-testing-videos/src/shadow_rect.tsx
@@ -1,0 +1,58 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Rect} from '@revideo/2d';
+import {all, createRef, waitFor} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  const rect = createRef<Rect>();
+
+  // Place a rectangle near the top-left to exercise shadow bbox expansion.
+  view.add(
+    <Rect
+      ref={rect}
+      x={-200}
+      y={-140}
+      width={200}
+      height={140}
+      fill={'#2E86DE'}
+      radius={16}
+      // Strong, colored shadow with offset to be clearly visible.
+      shadowColor={'rgba(0,0,0,0.8)'}
+      shadowBlur={24}
+      shadowOffset={{x: 24, y: 24}}
+    />,
+  );
+
+  // Small motion so caching/path updates are exercised with shadows.
+  yield* waitFor(0.2);
+  yield* all(rect().x(0, 0.6), rect().y(0, 0.6));
+  yield* waitFor(0.2);
+});
+
+export const project = makeProject({
+  name: 'shadow-rect',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/shadow_text_image.tsx
+++ b/packages/proximal-testing-videos/src/shadow_text_image.tsx
@@ -1,0 +1,67 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {makeScene2D, Txt, Img} from '@revideo/2d';
+import {all, createRef, waitFor} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  const title = createRef<Txt>();
+  const logo = createRef<Img>();
+
+  view.add(
+    <>
+      <Txt
+        ref={title}
+        x={0}
+        y={-100}
+        fontSize={64}
+        fill={'#1B1B1B'}
+        shadowColor={'rgba(0,0,0,0.7)'}
+        shadowBlur={20}
+        shadowOffset={{x: 12, y: 12}}
+      >
+        Shadowed Text
+      </Txt>
+      <Img
+        ref={logo}
+        y={80}
+        width={160}
+        src={'https://revideo-example-assets.s3.amazonaws.com/revideo-logo-white.png'}
+        shadowColor={'rgba(0,0,0,0.85)'}
+        shadowBlur={28}
+        shadowOffset={{x: 18, y: 14}}
+      />
+    </>,
+  );
+
+  yield* waitFor(0.3);
+  yield* all(title().x(-120, 0.6), logo().x(120, 0.6));
+  yield* waitFor(0.3);
+});
+
+export const project = makeProject({
+  name: 'shadow-text-image',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
This PR adds the generated environment file for **2d-node-drop-shadows**.

- Base branch (feature removed): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows
- Solution branch (feature restored): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution
- Feature diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-node-drop-shadows-solution