### PR TITLE
Add environment for 2d-gradient-fills-and-strokes

### DIFF
--- a/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
+++ b/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
@@ -1,0 +1,2 @@
+import 2d-gradient-fills-and-strokesEnvironment from "../environments/revideo-2d-gradient-fills-and-strokes/revideo-2d-gradient-fills-and-strokes.env";
+cat: /root/workspace/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts: No such file or directory

--- a/environments/revideo-2d-gradient-fills-and-strokes/revideo-2d-gradient-fills-and-strokes.env.ts
+++ b/environments/revideo-2d-gradient-fills-and-strokes/revideo-2d-gradient-fills-and-strokes.env.ts
@@ -1,0 +1,299 @@
+import { Environment } from "../../proximal/core/environment";
+import { RepoContainer } from "../../proximal/core/container/RepoContainer";
+import { TaskRunnerAgent } from "../../proximal/core/agents/TaskRunnerAgent";
+import repos from "../../repos/repos";
+
+const TASK_ID = "2d-gradient-fills-and-strokes";
+
+export const revideo2dGradientFillsAndStrokesEnvironment = new Environment({
+  id: `revideo-2d-gradient-fills-and-strokes`,
+  name: `revideo-2d-gradient-fills-and-strokes`,
+  description: `revideo-2d-gradient-fills-and-strokes`,
+  codebase: "Revideo",
+  task: `revideo-2d-gradient-fills-and-strokes`,
+  repoPath: repos.revideo.path,
+
+  setupEnvironment: async (container: RepoContainer) => {
+    console.log("🔧 Setting up Revideo environment...");
+
+    await container.exec({
+      command: "git fetch origin",
+      stream: true,
+    });
+
+    console.log("📍 Checking out latest base branch...");
+    await container.exec({
+      command: "git fetch origin 2d-gradient-fills-and-strokes-base && git checkout 2d-gradient-fills-and-strokes-base && git pull origin 2d-gradient-fills-and-strokes-base",
+      stream: true,
+    });
+
+    console.log("📦 Installing dependencies...");
+    await container.exec({
+      command: "npm install",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.resetDiffBaseline();
+
+    console.log("✅ Environment setup completed");
+  },
+
+  variants: {
+    "Difficult Prompt": async (container: RepoContainer, agent: TaskRunnerAgent) => {
+      console.log("🧠 Running difficult prompt variant...");
+
+      await agent.run(
+        `Removed the Gradient canvas style from the 2D renderer (linear/conic/radial). Gradient objects are no longer accepted in fill/stroke styles—only solid colors and patterns remain. When rendering/exporting videos, any shapes that previously used gradients will no longer display gradient transitions and will instead render with flat colors (or missing fill/stroke if no color fallback), altering the visual appearance of those scenes.`
+      );
+    },
+  },
+
+  setupTests: async (container: RepoContainer) => {
+    console.log("🧪 Setting up test environment...");
+
+    await container.exec({
+      command: "bash -lc 'git add -A && git stash push -u -m "agent-changes" || true'",
+      stream: true,
+    });
+
+    await container.exec({
+      command: `git restore --source origin/${summary.testBranch} -- packages/proximal-testing-videos`,
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-gradient-fills-and-strokes-solution",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/gradient_conic.tsx gradient_conic_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/gradient_linear.tsx gradient_linear_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/gradient_radial.tsx gradient_radial_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/gradient_stroke_linear.tsx gradient_stroke_linear_baseline.mp4",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-gradient-fills-and-strokes-base",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git stash pop || true",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    console.log("✅ Test setup completed");
+  },
+
+  tests: [
+    {
+      id: "compiles-correctly",
+      name: "Correctly compiles?",
+      description: "Test that code compiles correctly",
+      test: async (container: RepoContainer) => {
+        console.log("  Testing compile step...");
+        try {
+          const result = await container.exec({
+            command: "npx lerna run build --skip-nx-cache",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const exitCode = typeof result === "string" ? 0 : result.exitCode;
+          return exitCode === 0;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+    {
+      id: "2d-gradient-fills-and-strokes-1",
+      name: "Validate gradient_conic",
+      description: "Render baseline and solution for gradient_conic and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/gradient_conic.tsx gradient_conic_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/gradient_conic_baseline.mp4 packages/proximal-testing-videos/output/gradient_conic_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-gradient-fills-and-strokes-2",
+      name: "Validate gradient_linear",
+      description: "Render baseline and solution for gradient_linear and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/gradient_linear.tsx gradient_linear_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/gradient_linear_baseline.mp4 packages/proximal-testing-videos/output/gradient_linear_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-gradient-fills-and-strokes-3",
+      name: "Validate gradient_radial",
+      description: "Render baseline and solution for gradient_radial and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/gradient_radial.tsx gradient_radial_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/gradient_radial_baseline.mp4 packages/proximal-testing-videos/output/gradient_radial_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-gradient-fills-and-strokes-4",
+      name: "Validate gradient_stroke_linear",
+      description: "Render baseline and solution for gradient_stroke_linear and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/gradient_stroke_linear.tsx gradient_stroke_linear_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/gradient_stroke_linear_baseline.mp4 packages/proximal-testing-videos/output/gradient_stroke_linear_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    }
+  ],
+
+  prompt: `${environmentPrompt}`,
+  branches: {
+    base: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes",
+    solution: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution",
+    diff: "https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution",
+    testingPr: "",
+    environmentPr: "",
+  },
+});
+
+export default revideo2dGradientFillsAndStrokesEnvironment;

--- a/packages/proximal-testing-videos/src/gradient_conic.tsx
+++ b/packages/proximal-testing-videos/src/gradient_conic.tsx
@@ -1,0 +1,53 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Gradient} from '@revideo/2d';
+
+const scene = makeScene2D('gradient-conic', function* (view) {
+  view.add(
+    <Rect
+      size={[480, 360]}
+      fill={
+        new Gradient({
+          type: 'conic',
+          angle: 0,
+          from: [0, 0],
+          stops: [
+            {offset: 0.0, color: '#ff0000'},
+            {offset: 0.33, color: '#00ff00'},
+            {offset: 0.66, color: '#0000ff'},
+            {offset: 1.0, color: '#ff0000'},
+          ],
+        })
+      }
+      stroke={'#000000'}
+      lineWidth={2}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'gradient-conic',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/gradient_linear.tsx
+++ b/packages/proximal-testing-videos/src/gradient_linear.tsx
@@ -1,0 +1,52 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Gradient} from '@revideo/2d';
+
+const scene = makeScene2D('gradient-linear', function* (view) {
+  view.add(
+    <Rect
+      size={[480, 360]}
+      fill={
+        new Gradient({
+          type: 'linear',
+          from: [-240, 0],
+          to: [240, 0],
+          stops: [
+            {offset: 0, color: '#ff0000'},
+            {offset: 0.5, color: '#00ff00'},
+            {offset: 1, color: '#0000ff'},
+          ],
+        })
+      }
+      stroke={'#000000'}
+      lineWidth={2}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'gradient-linear',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/gradient_radial.tsx
+++ b/packages/proximal-testing-videos/src/gradient_radial.tsx
@@ -1,0 +1,53 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Gradient} from '@revideo/2d';
+
+const scene = makeScene2D('gradient-radial', function* (view) {
+  view.add(
+    <Rect
+      size={[480, 360]}
+      fill={
+        new Gradient({
+          type: 'radial',
+          from: [0, 0],
+          to: [0, 0],
+          fromRadius: 0,
+          toRadius: 240,
+          stops: [
+            {offset: 0, color: '#ffffff'},
+            {offset: 1, color: '#000000'},
+          ],
+        })
+      }
+      stroke={'#000000'}
+      lineWidth={2}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'gradient-radial',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/gradient_stroke_linear.tsx
+++ b/packages/proximal-testing-videos/src/gradient_stroke_linear.tsx
@@ -1,0 +1,51 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Gradient} from '@revideo/2d';
+
+const scene = makeScene2D('gradient-stroke-linear', function* (view) {
+  view.add(
+    <Rect
+      size={[420, 300]}
+      fill={null}
+      stroke={
+        new Gradient({
+          type: 'linear',
+          from: [-210, 0],
+          to: [210, 0],
+          stops: [
+            {offset: 0, color: '#ff0000'},
+            {offset: 1, color: '#0000ff'},
+          ],
+        })
+      }
+      lineWidth={40}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'gradient-stroke-linear',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {format: 'mp4'},
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
This PR adds the generated environment file for **2d-gradient-fills-and-strokes**.

- Base branch (feature removed): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes
- Solution branch (feature restored): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution
- Feature diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-gradient-fills-and-strokes-solution