### PR TITLE
Add environment for 2d-stroke-rendering

### DIFF
--- a/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
+++ b/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts
@@ -1,0 +1,2 @@
+import 2d-stroke-renderingEnvironment from "../environments/revideo-2d-stroke-rendering/revideo-2d-stroke-rendering.env";
+cat: /root/workspace/collections/session-session-mgd5w8xe-2a433b3b/session-session-mgd5w8xe-2a433b3b.collection.ts: No such file or directory

--- a/environments/revideo-2d-stroke-rendering/revideo-2d-stroke-rendering.env.ts
+++ b/environments/revideo-2d-stroke-rendering/revideo-2d-stroke-rendering.env.ts
@@ -1,0 +1,303 @@
+import { Environment } from "../../proximal/core/environment";
+import { RepoContainer } from "../../proximal/core/container/RepoContainer";
+import { TaskRunnerAgent } from "../../proximal/core/agents/TaskRunnerAgent";
+import repos from "../../repos/repos";
+
+const TASK_ID = "2d-stroke-rendering";
+
+export const revideo2dStrokeRenderingEnvironment = new Environment({
+  id: `revideo-2d-stroke-rendering`,
+  name: `revideo-2d-stroke-rendering`,
+  description: `revideo-2d-stroke-rendering`,
+  codebase: "Revideo",
+  task: `revideo-2d-stroke-rendering`,
+  repoPath: repos.revideo.path,
+
+  setupEnvironment: async (container: RepoContainer) => {
+    console.log("🔧 Setting up Revideo environment...");
+
+    await container.exec({
+      command: "git fetch origin",
+      stream: true,
+    });
+
+    console.log("📍 Checking out latest base branch...");
+    await container.exec({
+      command: "git fetch origin 2d-stroke-rendering-base && git checkout 2d-stroke-rendering-base && git pull origin 2d-stroke-rendering-base",
+      stream: true,
+    });
+
+    console.log("📦 Installing dependencies...");
+    await container.exec({
+      command: "npm install",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.resetDiffBaseline();
+
+    console.log("✅ Environment setup completed");
+  },
+
+  variants: {
+    "Difficult Prompt": async (container: RepoContainer, agent: TaskRunnerAgent) => {
+      console.log("🧠 Running difficult prompt variant...");
+
+      await agent.run(
+        `Removed stroke drawing for 2D shapes and text. Shapes no longer call context.stroke, text uses fillText only, and curve arrowheads (stroke-based) are not drawn. In rendered videos, outlines/borders and dashed strokes no longer appear—only fills are visible, and stroke-related properties (color, width, order) have no effect.`
+      );
+    },
+  },
+
+  setupTests: async (container: RepoContainer) => {
+    console.log("🧪 Setting up test environment...");
+
+    await container.exec({
+      command: "bash -lc 'git add -A && git stash push -u -m "agent-changes" || true'",
+      stream: true,
+    });
+
+    await container.exec({
+      command: `git restore --source origin/${summary.testBranch} -- packages/proximal-testing-videos`,
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-stroke-rendering-solution",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/stroke_rects.tsx stroke_rects_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/dashed_line.tsx dashed_line_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/text_stroke.tsx text_stroke_baseline.mp4 && node dist/render.js ./packages/proximal-testing-videos/src/curve_arrowheads.tsx curve_arrowheads_baseline.mp4",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git checkout 2d-stroke-rendering-base",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "git stash pop || true",
+      stream: true,
+    });
+
+    await container.exec({
+      command: "npm install && npx lerna run build --skip-nx-cache",
+      stream: true,
+    });
+
+    console.log("✅ Test setup completed");
+  },
+
+  tests: [
+    {
+      id: "compiles-correctly",
+      name: "Correctly compiles?",
+      description: "Test that code compiles correctly",
+      test: async (container: RepoContainer) => {
+        console.log("  Testing compile step...");
+        try {
+          const result = await container.exec({
+            command: "npx lerna run build --skip-nx-cache",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const exitCode = typeof result === "string" ? 0 : result.exitCode;
+          return exitCode === 0;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+    {
+      id: "2d-stroke-rendering-1",
+      name: "Validate stroke_rects",
+      description: "Render baseline and solution for stroke_rects and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/stroke_rects.tsx stroke_rects_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/stroke_rects_baseline.mp4 packages/proximal-testing-videos/output/stroke_rects_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/stroke_rects_baseline.mp4 packages/proximal-testing-videos/output/stroke_rects_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-stroke-rendering-2",
+      name: "Validate dashed_line",
+      description: "Render baseline and solution for dashed_line and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/dashed_line.tsx dashed_line_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/dashed_line_baseline.mp4 packages/proximal-testing-videos/output/dashed_line_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/dashed_line_baseline.mp4 packages/proximal-testing-videos/output/dashed_line_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-stroke-rendering-3",
+      name: "Validate text_stroke",
+      description: "Render baseline and solution for text_stroke and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/text_stroke.tsx text_stroke_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/text_stroke_baseline.mp4 packages/proximal-testing-videos/output/text_stroke_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/text_stroke_baseline.mp4 packages/proximal-testing-videos/output/text_stroke_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    },
+
+    {
+      id: "2d-stroke-rendering-4",
+      name: "Validate curve_arrowheads",
+      description: "Render baseline and solution for curve_arrowheads and compare outputs.",
+      test: async (container: RepoContainer) => {
+        try {
+          const renderResult = await container.exec({
+            command: "cd packages/proximal-testing-videos && npx tsc && node dist/render.js ./packages/proximal-testing-videos/src/curve_arrowheads.tsx curve_arrowheads_solution.mp4",
+            throwOnError: false,
+            stream: true,
+          });
+
+          const renderExit = typeof renderResult === "string" ? 0 : renderResult.exitCode;
+          if (renderExit !== 0) {
+            return false;
+          }
+
+          const commands = [
+            "bash packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh packages/proximal-testing-videos/output/curve_arrowheads_baseline.mp4 packages/proximal-testing-videos/output/curve_arrowheads_solution.mp4",
+            "bash packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh packages/proximal-testing-videos/output/curve_arrowheads_baseline.mp4 packages/proximal-testing-videos/output/curve_arrowheads_solution.mp4"
+          ];
+
+          for (const command of commands) {
+            const result = await container.exec({
+              command,
+              throwOnError: false,
+              stream: true,
+            });
+            const exitCode = typeof result === "string" ? 0 : result.exitCode;
+            if (exitCode !== 0) {
+              return false;
+            }
+          }
+
+          return true;
+        } catch (error) {
+          console.error("Test execution error:", error);
+          return false;
+        }
+      },
+    }
+  ],
+
+  prompt: `${environmentPrompt}`,
+  branches: {
+    base: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering",
+    solution: "testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution",
+    diff: "https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution",
+    testingPr: "",
+    environmentPr: "",
+  },
+});
+
+export default revideo2dStrokeRenderingEnvironment;

--- a/packages/proximal-testing-videos/src/curve_arrowheads.tsx
+++ b/packages/proximal-testing-videos/src/curve_arrowheads.tsx
@@ -1,0 +1,61 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Line, makeScene2D, Txt} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Txt y={-200} fontSize={32} fill={'#333'}>
+      Polyline with end arrowhead
+    </Txt>,
+  );
+
+  // A simple polyline with an end arrow; arrowheads use stroke color
+  view.add(
+    <Line
+      stroke={'#2E7D32'}
+      lineWidth={14}
+      lineCap={'round'}
+      endArrow
+      arrowSize={22}
+      points={[
+        [-220, 60],
+        [-80, -20],
+        [80, 20],
+        [200, -40],
+      ]}
+    />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/dashed_line.tsx
+++ b/packages/proximal-testing-videos/src/dashed_line.tsx
@@ -1,0 +1,59 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Line, makeScene2D, Txt} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Txt y={-200} fontSize={32} fill={'#333'}>
+      Dashed line stroke
+    </Txt>,
+  );
+
+  view.add(
+    <Line
+      stroke={'#D9534F'}
+      lineWidth={16}
+      lineCap={'butt'}
+      lineDash={[24, 16]}
+      points={[
+        [-220, 0],
+        [-80, -40],
+        [80, 40],
+        [220, 0],
+      ]}
+    />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/stroke_rects.tsx
+++ b/packages/proximal-testing-videos/src/stroke_rects.tsx
@@ -1,0 +1,74 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Txt} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+export const scene = makeScene2D('scene', function* (view) {
+  // Title for context in debugging
+  view.add(
+    <Txt y={-200} fontSize={32} fill={'#333'}>
+      Rect strokes: left fill-then-stroke, right stroke-then-fill
+    </Txt>,
+  );
+
+  // Left: stroke after fill (default)
+  view.add(
+    <Rect
+      x={-150}
+      width={200}
+      height={140}
+      radius={24}
+      fill={'#FFD966'}
+      stroke={'#1F1F1F'}
+      lineWidth={24}
+      strokeFirst={false}
+    />,
+  );
+
+  // Right: stroke before fill
+  view.add(
+    <Rect
+      x={150}
+      width={200}
+      height={140}
+      radius={24}
+      fill={'#93C47D'}
+      stroke={'#1F1F1F'}
+      lineWidth={24}
+      strokeFirst={true}
+    />,
+  );
+
+  // Keep a small duration so there is a stable frame to render
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/text_stroke.tsx
+++ b/packages/proximal-testing-videos/src/text_stroke.tsx
@@ -1,0 +1,49 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, Txt, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+export const scene = makeScene2D('scene', function* (view) {
+  // Background to highlight the outline contrast
+  view.add(<Rect width={'100%'} height={'100%'} fill={'#F0F0F0'} />);
+
+  view.add(
+    <Txt fontFamily={"'JetBrains Mono', monospace"} fontWeight={800} fontSize={92}>
+      <Txt fill={'#1E90FF'} stroke={'#000000'} lineWidth={12} strokeFirst={false}>
+        Outline Text
+      </Txt>
+    </Txt>,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
This PR adds the generated environment file for **2d-stroke-rendering**.

- Base branch (feature removed): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering
- Solution branch (feature restored): https://github.com/Proximal-Labs/task-demo-revideo/tree/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution
- Feature diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering...testing-branch-session-mgd5w8xe-2a433b3b-env-2d-stroke-rendering-solution