### PR TITLE
Add tests for canvas-pattern-support

### DIFF
--- a/packages/proximal-testing-videos/src/pattern_fill_rect.tsx
+++ b/packages/proximal-testing-videos/src/pattern_fill_rect.tsx
@@ -1,0 +1,76 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D, Pattern} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  // Create a small canvas tile to be used as a repeating pattern.
+  const tile = document.createElement('canvas');
+  tile.width = 32;
+  tile.height = 32;
+  const ctx = tile.getContext('2d')!;
+
+  // Draw a simple checkerboard-like tile with contrasting colors.
+  ctx.fillStyle = '#f2f2f2';
+  ctx.fillRect(0, 0, tile.width, tile.height);
+  ctx.fillStyle = '#ff5252';
+  ctx.fillRect(0, 0, 16, 16);
+  ctx.fillStyle = '#40c4ff';
+  ctx.fillRect(16, 16, 16, 16);
+  ctx.strokeStyle = '#263238';
+  ctx.lineWidth = 2;
+  ctx.beginPath();
+  ctx.moveTo(0, 0);
+  ctx.lineTo(tile.width, tile.height);
+  ctx.moveTo(tile.width, 0);
+  ctx.lineTo(0, tile.height);
+  ctx.stroke();
+
+  const pattern = new Pattern({image: tile, repetition: 'repeat'});
+
+  view.add(
+    <Rect
+      width={440}
+      height={320}
+      position={[0, 0]}
+      radius={16}
+      // The tested feature: CanvasPattern-based fill
+      fill={pattern}
+      // Add a visible outline to make differences very apparent if fill fails
+      stroke={'#000'}
+      lineWidth={6}
+    />,
+  );
+
+  // Hold for a brief moment to produce a short video
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'pattern_fill_rect',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/pattern_stroke_circle.tsx
+++ b/packages/proximal-testing-videos/src/pattern_stroke_circle.tsx
@@ -1,0 +1,73 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Circle, Rect, makeScene2D, Pattern} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  // Background block so the patterned stroke is clearly visible
+  view.add(
+    <Rect width={'100%'} height={'100%'} fill={'#fafafa'} />,
+  );
+
+  // Create a stripe tile for the stroke pattern
+  const tile = document.createElement('canvas');
+  tile.width = 32;
+  tile.height = 32;
+  const ctx = tile.getContext('2d')!;
+
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, tile.width, tile.height);
+  ctx.strokeStyle = '#7b1fa2';
+  ctx.lineWidth = 6;
+  ctx.beginPath();
+  ctx.moveTo(-8, 8);
+  ctx.lineTo(40, 56);
+  ctx.moveTo(-8, -8);
+  ctx.lineTo(40, 40);
+  ctx.stroke();
+
+  const strokePattern = new Pattern({image: tile, repetition: 'repeat'});
+
+  view.add(
+    <Circle
+      size={300}
+      position={[0, 0]}
+      // The tested feature: CanvasPattern-based stroke
+      stroke={strokePattern}
+      lineWidth={36}
+      // Explicitly no fill to focus on stroke rendering
+      fill={null}
+    />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'pattern_stroke_circle',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#ffffff',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
# Feature Removal Session session-mgd6lfme-af3b5f6e

## Summary
- Total features: 2
- Testing branch: testing-branch-session-mgd6lfme-af3b5f6e
- Environment branch prefix: environments-session-mgd6lfme-af3b5f6e
- Base testing branch: testing-branch

## Features

### canvas-pattern-support
Removed support for CanvasPattern-based styles (Pattern class) for fills and strokes in the 2D renderer. Only colors and gradients are now accepted. When rendering videos, any elements that previously used image patterns will no longer display the pattern and will render without it (falling back to a solid color/gradient if present, otherwise appearing with no fill/stroke).

- Branches:
  - Base: testing-branch-session-mgd6lfme-af3b5f6e-env-canvas-pattern-support
  - Solution: testing-branch-session-mgd6lfme-af3b5f6e-env-canvas-pattern-support-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd6lfme-af3b5f6e-env-canvas-pattern-support...testing-branch-session-mgd6lfme-af3b5f6e-env-canvas-pattern-support-solution
- Testing PRs:
  - Tests: https://github.com/Proximal-Environments/revideo-env/pull/29
- Environment:
  - Branch: environments-session-mgd6lfme-af3b5f6e
- Tests:
  - packages/proximal-testing-videos/src/pattern_fill_rect.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/pattern_stroke_circle.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh

### text-wrapping-support
Removed automatic text wrapping and 'pre' whitespace handling for 2D text nodes. Layout now forces white-space: nowrap and TxtLeaf sets innerText directly (no segmentation/newline preservation). When rendering videos, any previously wrapped or multi-line text will appear as a single unbroken line and may overflow its container, changing the visual layout of captions and text blocks.

- Branches:
  - Base: testing-branch-session-mgd6lfme-af3b5f6e-env-text-wrapping-support
  - Solution: testing-branch-session-mgd6lfme-af3b5f6e-env-text-wrapping-support-solution
  - Diff: https://github.com/Proximal-Labs/task-demo-revideo/compare/testing-branch-session-mgd6lfme-af3b5f6e-env-text-wrapping-support...testing-branch-session-mgd6lfme-af3b5f6e-env-text-wrapping-support-solution
- Environment:
  - Branch: environments-session-mgd6lfme-af3b5f6e
  - PR: https://github.com/Proximal-Environments/revideo-env/pull/30
- Tests:
  - packages/proximal-testing-videos/src/text_wrap_basic.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
  - packages/proximal-testing-videos/src/text_whitespace_pre.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh