### PR TITLE
Add tests for 2d-node-blend-modes

### DIFF
--- a/packages/proximal-testing-videos/src/blend_multiply_over_image.tsx
+++ b/packages/proximal-testing-videos/src/blend_multiply_over_image.tsx
@@ -1,0 +1,78 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {all, createRef, waitFor} from '@revideo/core';
+
+// Tests per-node compositeOperation by overlaying a rectangle with 'multiply'
+// over an image background. Visual output differs from normal source-over.
+export const scene = makeScene2D('scene', function* (view) {
+  const overlayRef = createRef<Rect>();
+
+  // Synthetic, high-contrast background: two stacked color bands
+  view.add(
+    <>
+      <Rect
+        size={['100%', '50%']}
+        position={[0, -120]}
+        fill={'#1E3A8A'} // deep blue
+      />
+      <Rect
+        size={['100%', '50%']}
+        position={[0, 120]}
+        fill={'#A21CAF'} // magenta
+      />
+    </>,
+  );
+
+  // Wait a moment before animating
+  yield* waitFor(0.2);
+
+  // Semi-transparent yellow overlay using multiply to darken background
+  view.add(
+    <Rect
+      ref={overlayRef}
+      width={'60%'}
+      height={'60%'}
+      fill={'rgba(255, 230, 0, 0.65)'}
+      position={[0, 0]}
+      compositeOperation={'multiply'}
+      radius={30}
+      smoothCorners
+    />,
+  );
+
+  // Animate to create multiple frames for hashing
+  yield* all(
+    overlayRef().rotation(30, 1.0),
+    overlayRef().position([100, -60], 1.0),
+  );
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#000000',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;

--- a/packages/proximal-testing-videos/src/mask_destination_out.tsx
+++ b/packages/proximal-testing-videos/src/mask_destination_out.tsx
@@ -1,0 +1,69 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Circle, Rect, makeScene2D} from '@revideo/2d';
+import {all, createRef, waitFor} from '@revideo/core';
+
+// Tests destination-out masking: a moving circle cuts a hole in a rectangle.
+// Without compositeOperation support, the circle draws normally instead of masking.
+export const scene = makeScene2D('scene', function* (view) {
+  const holeRef = createRef<Circle>();
+
+  // Solid background rectangle
+  view.add(
+    <Rect size={['100%', '100%']} fill={'#204070'} />,
+  );
+
+  // Foreground rectangle we will punch a hole into
+  view.add(
+    <Rect width={'70%'} height={'50%'} fill={'#FF6A00'} radius={20} smoothCorners />,
+  );
+
+  yield* waitFor(0.2);
+
+  // Moving circle with destination-out to cut a hole
+  view.add(
+    <Circle
+      ref={holeRef}
+      width={180}
+      height={180}
+      compositeOperation={'destination-out'}
+      position={[-150, 0]}
+      fill={'#000'}
+    />,
+  );
+
+  // Animate the hole across the rectangle
+  yield* all(
+    holeRef().position([150, 0], 1.2),
+  );
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/tween_composite_operation.tsx
+++ b/packages/proximal-testing-videos/src/tween_composite_operation.tsx
@@ -1,0 +1,83 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+import {all, createRef, waitFor} from '@revideo/core';
+
+// Tests tween/override logic when animating compositeOperation.
+// We tween from source-over to screen, then back to source-over.
+export const scene = makeScene2D('scene', function* (view) {
+  const overlayRef = createRef<Rect>();
+
+  // High-contrast background improves visibility of blend changes
+  view.add(
+    <>
+      <Rect
+        size={['100%', '50%']}
+        position={[0, -120]}
+        fill={'#143C2E'} // dark green
+      />
+      <Rect
+        size={['100%', '50%']}
+        position={[0, 120]}
+        fill={'#7C2D12'} // dark orange
+      />
+    </>,
+  );
+
+  // Overlay rectangle starts as normal composition
+  view.add(
+    <Rect
+      ref={overlayRef}
+      width={'70%'}
+      height={'60%'}
+      fill={'rgba(80, 180, 255, 0.7)'}
+      position={[0, 0]}
+      radius={24}
+      smoothCorners
+      compositeOperation={'source-over'}
+    />,
+  );
+
+  yield* waitFor(0.3);
+
+  // Tween into 'screen' over 1.0s (should gradually brighten due to override)
+  yield* overlayRef().compositeOperation('screen', 1.0);
+
+  // Add some movement/rotation while in screen mode
+  yield* all(
+    overlayRef().rotation(20, 0.8),
+    overlayRef().position([-80, -40], 0.8),
+  );
+
+  // Tween back to source-over over 0.8s
+  yield* overlayRef().compositeOperation('source-over', 0.8);
+});
+
+export const project = makeProject({
+  name: 'project',
+  scenes: [scene],
+  variables: {},
+  settings: {
+    shared: {
+      background: '#000000',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;


### PR DESCRIPTION
Automated test plan for 2d-node-blend-modes:

- packages/proximal-testing-videos/src/mask_destination_out.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/blend_multiply_over_image.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh
- packages/proximal-testing-videos/src/tween_composite_operation.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh, packages/proximal-testing-videos/testing_scripts/test_video_length_similar.sh