### PR TITLE
Add tests for img-video-alpha-prop

### DIFF
--- a/packages/proximal-testing-videos/src/img_alpha_half.tsx
+++ b/packages/proximal-testing-videos/src/img_alpha_half.tsx
@@ -1,0 +1,45 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Img, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+// Purpose: Validate per-media alpha blending on Img (alpha=0.5)
+// Expectation (gold): Image blends with background; (removed feature): fully opaque image
+
+const scene = makeScene2D('scene', function* (view) {
+  // Give the image time to load before first frame capture
+  yield* waitFor(0.1);
+
+  view.add(
+    <Img
+      src={'https://revideo-example-assets.s3.amazonaws.com/revideo-logo-white.png'}
+      width={'60%'}
+      alpha={0.5}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'img_alpha_half',
+  scenes: [scene],
+  settings: {
+    shared: {
+      // Strong colored background to make blending differences obvious
+      background: '#0044FF',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: { name: '@revideo/core/ffmpeg', options: { format: 'mp4' } },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/img_alpha_zero.tsx
+++ b/packages/proximal-testing-videos/src/img_alpha_zero.tsx
@@ -1,0 +1,40 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Img, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+// Purpose: Validate alpha=0 on Img (should skip drawing)
+// Expectation (gold): Only background visible; (removed feature): image shows fully opaque
+
+const scene = makeScene2D('scene', function* (view) {
+  yield* waitFor(0.1);
+
+  view.add(
+    <Img
+      src={'https://revideo-example-assets.s3.amazonaws.com/revideo-logo-white.png'}
+      width={'60%'}
+      alpha={0}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'img_alpha_zero',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#AA2222',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: { fps: 30, resolutionScale: 1 },
+    rendering: {
+      exporter: { name: '@revideo/core/ffmpeg', options: { format: 'mp4' } },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/video_alpha_half.tsx
+++ b/packages/proximal-testing-videos/src/video_alpha_half.tsx
@@ -1,0 +1,41 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Video, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+// Purpose: Validate per-media alpha blending on Video (alpha=0.5)
+// Expectation (gold): Video blends with background; (removed feature): fully opaque video
+
+const scene = makeScene2D('scene', function* (view) {
+  yield* waitFor(0.1);
+
+  view.add(
+    <Video
+      src={'https://revideo-example-assets.s3.amazonaws.com/stars.mp4'}
+      size={['100%', '100%']}
+      play={true}
+      alpha={0.5}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'video_alpha_half',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#00AA66',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: { fps: 30, resolutionScale: 1 },
+    rendering: {
+      exporter: { name: '@revideo/core/ffmpeg', options: { format: 'mp4' } },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/video_alpha_zero.tsx
+++ b/packages/proximal-testing-videos/src/video_alpha_zero.tsx
@@ -1,0 +1,41 @@
+import {makeProject, Vector2} from '@revideo/core';
+import {Video, makeScene2D} from '@revideo/2d';
+import {waitFor} from '@revideo/core';
+
+// Purpose: Validate alpha=0 on Video (should skip drawing)
+// Expectation (gold): Only background visible; (removed feature): video shows fully opaque
+
+const scene = makeScene2D('scene', function* (view) {
+  yield* waitFor(0.1);
+
+  view.add(
+    <Video
+      src={'https://revideo-example-assets.s3.amazonaws.com/stars.mp4'}
+      size={['100%', '100%']}
+      play={true}
+      alpha={0}
+    />,
+  );
+});
+
+export const project = makeProject({
+  name: 'video_alpha_zero',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#333333',
+      range: [0, 1],
+      size: new Vector2(640, 480),
+    },
+    preview: { fps: 30, resolutionScale: 1 },
+    rendering: {
+      exporter: { name: '@revideo/core/ffmpeg', options: { format: 'mp4' } },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Automated test plan for img-video-alpha-prop:

- packages/proximal-testing-videos/src/img_alpha_zero.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
- packages/proximal-testing-videos/src/img_alpha_half.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
- packages/proximal-testing-videos/src/video_alpha_zero.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh
- packages/proximal-testing-videos/src/video_alpha_half.tsx: packages/proximal-testing-videos/testing_scripts/test_visual_equivalence.sh