### PR TITLE
Batch testing updates (2025-10-05T08-21-37-510Z)

### DIFF
--- a/packages/proximal-testing-videos/src/text_font_family.tsx
+++ b/packages/proximal-testing-videos/src/text_font_family.tsx
@@ -1,0 +1,54 @@
+import {Txt, Rect, makeScene2D} from '@revideo/2d';
+import {waitFor, makeProject, Vector2} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.add(<Rect size={'100%'} fill={'#ffffff'} />);
+
+  // Title
+  view.add(
+    <Txt y={-200} text={'Font Family Overrides'} fontSize={36} fontWeight={700} />,
+  );
+
+  // Three lines using generic families to avoid custom font installs.
+  view.add(
+    <Txt y={-80} text={'Monospace family'} fontFamily={'monospace'} fontSize={48} />,
+  );
+  view.add(
+    <Txt y={0} text={'Serif family'} fontFamily={'serif'} fontSize={48} />,
+  );
+  view.add(
+    <Txt y={80} text={'Sans-serif family'} fontFamily={'sans-serif'} fontSize={48} />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'text_font_family',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/text_lineheight_letterspacing.tsx
+++ b/packages/proximal-testing-videos/src/text_lineheight_letterspacing.tsx
@@ -1,0 +1,63 @@
+import {Txt, Rect, makeScene2D} from '@revideo/2d';
+import {waitFor, makeProject, Vector2} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.add(<Rect size={'100%'} fill={'#ffffff'} />);
+
+  view.add(
+    <Txt y={-200} text={'Line-Height / Letter-Spacing'} fontSize={36} fontWeight={700} />,
+  );
+
+  // Multi-line with custom line-height; also reduce font size to accentuate difference
+  view.add(
+    <Txt
+      y={-60}
+      text={'Line A\nLine B\nLine C'}
+      fontSize={30}
+      lineHeight={100}
+      textAlign={'center'}
+    />,
+  );
+
+  // Large letter spacing
+  view.add(
+    <Txt
+      y={100}
+      text={'S P A C E D'}
+      fontSize={48}
+      letterSpacing={8}
+    />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'text_lineheight_letterspacing',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/text_size_weight_style.tsx
+++ b/packages/proximal-testing-videos/src/text_size_weight_style.tsx
@@ -1,0 +1,57 @@
+import {Txt, Rect, makeScene2D} from '@revideo/2d';
+import {waitFor, makeProject, Vector2} from '@revideo/core';
+
+const scene = makeScene2D('scene', function* (view) {
+  view.add(<Rect size={'100%'} fill={'#ffffff'} />);
+
+  view.add(
+    <Txt y={-200} text={'Font Size / Weight / Style'} fontSize={36} fontWeight={700} />,
+  );
+
+  // Big vs default size
+  view.add(
+    <Txt y={-100} text={'Size 96'} fontSize={96} />,
+  );
+
+  // Bold vs normal
+  view.add(
+    <Txt y={0} text={'Weight 800'} fontWeight={800} fontSize={48} />,
+  );
+
+  // Italic vs normal
+  view.add(
+    <Txt y={100} text={'Italic style'} fontStyle={'italic'} fontSize={48} />,
+  );
+
+  yield* waitFor(1);
+});
+
+export const project = makeProject({
+  name: 'text_size_weight_style',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Batch testing updates for 1 environments.

- Batch ID: 2025-10-05T08-21-37-510Z
- Branch: testing-branch-2025-10-05T08-21-37-510Z

- **per-node-text-font-styling**: Removed support for per-node text font overrides (font-family, font-size, font-style, font-weight, line-height, letter-spacing). These styles are no longer applied to DOM/canvas. When rendering videos, text now uses the default scene/browser font and default metrics; custom fonts, sizes, letter-spacing, and line-heights are ignored, which can change text appearance and layout.