### PR TITLE
Batch testing updates (2025-10-05T20-18-13-020Z)

### DIFF
--- a/packages/proximal-testing-videos/src/skew_both_rect.tsx
+++ b/packages/proximal-testing-videos/src/skew_both_rect.tsx
@@ -1,0 +1,51 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+
+// Static scene showing combined X and Y skew
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Rect
+      width={260}
+      height={160}
+      x={0}
+      y={0}
+      fill={'#55CC55'}
+      stroke={'#1F5F1F'}
+      lineWidth={4}
+      skewX={20}
+      skewY={10}
+    />,
+  );
+
+  yield* waitFor(0.8);
+});
+
+export const project = makeProject({
+  name: 'skew_both_rect',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/skew_with_transform.tsx
+++ b/packages/proximal-testing-videos/src/skew_with_transform.tsx
@@ -1,0 +1,55 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Rect, makeScene2D, Layout} from '@revideo/2d';
+
+// Scene combining translation, rotation, scaling and skew to test composition order
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Layout x={-80} y={-30} rotation={15}>
+      <Rect
+        width={220}
+        height={140}
+        x={0}
+        y={0}
+        fill={'#AA66CC'}
+        stroke={'#3E1F4F'}
+        lineWidth={4}
+        scaleX={1.2}
+        scaleY={0.9}
+        skewX={30}
+        skewY={12}
+      />
+    </Layout>,
+  );
+
+  yield* waitFor(0.8);
+});
+
+export const project = makeProject({
+  name: 'skew_with_transform',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/skewx_rect.tsx
+++ b/packages/proximal-testing-videos/src/skewx_rect.tsx
@@ -1,0 +1,51 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+
+// Static scene showing a clear X-skew on a rectangle
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Rect
+      width={300}
+      height={150}
+      x={0}
+      y={0}
+      fill={'#00AAFF'}
+      stroke={'#002244'}
+      lineWidth={4}
+      skewX={30}
+    />,
+  );
+
+  // Keep the frame for a moment to render a short clip
+  yield* waitFor(0.8);
+});
+
+export const project = makeProject({
+  name: 'skewx_rect',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+

--- a/packages/proximal-testing-videos/src/skewy_rect.tsx
+++ b/packages/proximal-testing-videos/src/skewy_rect.tsx
@@ -1,0 +1,50 @@
+import {makeProject, Vector2, waitFor} from '@revideo/core';
+import {Rect, makeScene2D} from '@revideo/2d';
+
+// Static scene showing a clear Y-skew on a rectangle
+export const scene = makeScene2D('scene', function* (view) {
+  view.add(
+    <Rect
+      width={300}
+      height={150}
+      x={0}
+      y={0}
+      fill={'#FF8800'}
+      stroke={'#662200'}
+      lineWidth={4}
+      skewY={25}
+    />,
+  );
+
+  yield* waitFor(0.8);
+});
+
+export const project = makeProject({
+  name: 'skewy_rect',
+  scenes: [scene],
+  settings: {
+    shared: {
+      background: '#FFFFFF',
+      range: [0, Infinity],
+      size: new Vector2(640, 480),
+    },
+    preview: {
+      fps: 30,
+      resolutionScale: 1,
+    },
+    rendering: {
+      exporter: {
+        name: '@revideo/core/ffmpeg',
+        options: {
+          format: 'mp4',
+        },
+      },
+      fps: 30,
+      resolutionScale: 1,
+      colorSpace: 'srgb',
+    },
+  },
+});
+
+export default project;
+


### PR DESCRIPTION
Batch testing updates for 3 environments.

- Batch ID: 2025-10-05T20-18-13-020Z
- Branch: testing-branch-2025-10-05T20-18-13-020Z

- **resolution-scale-rendering**: Removed the resolutionScale-based rendering/upscaling across the pipeline (Stage, Player, Renderer, GeneratorScene, FFmpeg, UI). The canvas and scenes no longer multiply size by resolutionScale; it is fixed to 1. FFmpeg exports now use the base project size with no internal scaling. When rendering videos, outputs always match the project’s base resolution; any prior high-DPI exports using resolutionScale > 1 will now render at lower dimensions with reduced sharpness. ResolutionScale inputs are ignored.
- **node-skew-transform**: Previously, 2D nodes applied skew (skew/skewX/skewY) to their local transform matrix, producing slanted shapes. The skew application has been removed from the render path: the skew properties still exist but no longer affect rendering. When rendering videos, any configured skew now has no visual effect—content renders unskewed—while position, rotation, and scale remain unchanged.
- **stage-background-fill**: Removed automatic background color fill in the Stage and the client-side background override. Previously, the canvas was filled with the project’s background color before compositing, and exports could override this color. Now, the background setting is ignored: rendered videos/frames no longer include a solid background fill—unpainted areas remain transparent (or may appear black depending on the encoder). Projects that relied on a white/custom background will render without it.